### PR TITLE
Add CI status support

### DIFF
--- a/index.html.pre
+++ b/index.html.pre
@@ -143,6 +143,7 @@ a.blocked {
 <h1>Merge list</h1>
 
 <h3>Last update: UPDATE_TIMESTAMP</h3>
+<h3>CI: CI_STATUS</h3>
 
 <table class="prs" id="author">
   <tr>


### PR DESCRIPTION
Add one more line before the table showing the status of CI runs on the main branch.

---

Looks like

![a](https://github.com/zephyrproject-rtos/zephyr-merge-list/assets/891546/cc98fde4-5ef5-45e3-a735-fc54514beec3)
![x](https://github.com/zephyrproject-rtos/zephyr-merge-list/assets/891546/85c71154-3f5e-4208-b83e-336082ac0557)

The labels are linked to the run as well.