### PR TITLE
Handle workflow in queued state

### DIFF
--- a/merge_list.py
+++ b/merge_list.py
@@ -209,7 +209,7 @@ def get_ci_status(repo):
                 status.append(f"<a href={html_url}>{name} {FAIL}</a>")
             else:
                 print(f"ignoring conclusion: {run.conclusion}")
-        elif run.status == "in_progress":
+        elif run.status in ["in_progress", "queued"]:
             delta = datetime.datetime.now(UTC) - run.run_started_at.astimezone(UTC)
             delta_mins = int(delta.total_seconds() / 60)
             jobs = list(run.jobs())


### PR DESCRIPTION
Process queued workflow in the same way as in progress ones, this makes sure that they show up in the dashboard as well.