### PR TITLE
Sort the list by mergeable staus, then PR number

### DIFF
--- a/merge_list.py
+++ b/merge_list.py
@@ -320,7 +320,11 @@ def main(argv):
         debug_data.append(data.debug)
     print(tabulate.tabulate(debug_data, headers=debug_headers))
 
+    data_out = []
     for number, data in pr_data.items():
+        data_out.append(((data.assignee and data.time, number), data))
+
+    for (_, number), data in sorted(data_out, key=lambda x: x[0], reverse=True):
         html_out += table_entry(number, data)
 
     with open(HTML_POST) as f:


### PR DESCRIPTION
Add an extra processing so that the output list puts mergeable PRs on top.

---

Looks like this:

![dP5TmRjxDG9DTbm](https://github.com/zephyrproject-rtos/zephyr-merge-list/assets/891546/3c2bc1ad-fa18-416b-972b-e76a1f51ef54)

@jhedberg