### PR TITLE
 Add a MOTD feature

### DIFF
--- a/index.html.pre
+++ b/index.html.pre
@@ -113,15 +113,48 @@ a.blocked {
 	font-style: italic;
 	opacity: 0.5;
 }
+
+.motd {
+	margin-left: auto;
+	margin-right: auto;
+	border: 3px solid red;
+	margin-top: 10px;
+	margin-bottom: 10px;
+}
 </style>
 
 <script type="text/javascript">
+	function load_motd() {
+		const url = "https://raw.githubusercontent.com/wiki/zephyrproject-rtos/zephyr/Merge-List-MOTD.md"
+		fetch(url)
+			.then((response) => {
+				if (!response.ok) {
+					throw new Error('HTTP error: ' + response.status);
+				}
+				return response.text()
+			})
+			.then((text) => {
+				console.log('motd: ' + text)
+
+				if (text == 'empty') {
+					return
+				}
+
+				const motd_table = document.getElementById('motd-table');
+				const motd_text = document.getElementById('motd-text');
+				motd_text.textContent = text
+				motd_table.hidden = false
+			});
+	}
+
 	function load() {
 		var checkbox = document.getElementById('autoRefreshCheckbox');
 		var value = localStorage.getItem('autoRefresh');
 		if (value == "true") {
 			checkbox.checked = true;
 		}
+
+		load_motd();
 	}
 
 	function refreshSave() {
@@ -144,6 +177,10 @@ a.blocked {
 
 <h3>Last update: UPDATE_TIMESTAMP</h3>
 <h3>CI: CI_STATUS</h3>
+
+<table class="motd" id="motd-table" hidden>
+  <tr><td id="motd-text"></td></tr>
+</table>
 
 <table class="prs" id="author">
   <tr>


### PR DESCRIPTION
Add a "message of the day" feature that fetches the content of the wiki page at https://github.com/zephyrproject-rtos/zephyr/wiki/Merge-List-MOTD and displays it on the page if it's not empty. As in: if the content is not "empty", the GitHub wiki does not allow pushing an actual empty page.

--

Hey I think this is safe from XSS since it uses textContent but please chime in if you know more about it, I don't really have much experience on that front. HTML tags are printed as text, Emojis are displays (sorry) updates are delayed by 5mins or so server side, does not seem like I can do much about it.

Dark demo:

![x](https://github.com/zephyrproject-rtos/zephyr-merge-list/assets/891546/7d2b8d7a-311c-4835-8ed8-4548caad6985)

Light demo:

![x](https://github.com/zephyrproject-rtos/zephyr-merge-list/assets/891546/b98da46c-4dd0-4bdd-b750-e3eb6e5ad49c)
