### PR TITLE
Get the milestone data consistently

### DIFF
--- a/merge_list.py
+++ b/merge_list.py
@@ -127,6 +127,7 @@ def evaluate_criteria(number, data):
 
 def table_entry(number, data):
     pr = data.pr
+    issue = data.issue
     url = pr.html_url
     title = html.escape(pr.title)
     author = html.escape(pr.user.login)
@@ -134,8 +135,8 @@ def table_entry(number, data):
     approvers = html.escape(', '.join(sorted(data.approvers)))
 
     base = pr.base.ref
-    if pr.milestone:
-        milestone = pr.milestone.title
+    if issue.milestone:
+        milestone = issue.milestone.title
     else:
         milestone = ""
 


### PR DESCRIPTION
GitHub stores PR data in both the PR and Issue data structures and the script fetches them at different times. This means that the PR data, which is fetched later, may lag behind. For the milestone detection this may result a PR getting through the milestone filter (which uses the issue data) and then getting displayed with a milestone that should be filtered (if the milestone has been applied in that time), because right now the filtering is on issue.milestone but the page is using pr.milestone.

Fix that by switching the display code to issue.milestone, at list it's consistent, either way it would render correctly on the next run.