### PR TITLE
workflow: run the script in unbuffered mode

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -33,7 +33,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir public
-          ./merge_list.py --self ${{ github.repository }}
+          python -u merge_list.py --self ${{ github.repository }}
 
       - name: Setup pages
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Use "python -u" to run the script so that prints are flushed and hopefully show up on the action log immediately.