### PR TITLE
Tags rework, highlight old CI runs and DNM

### DIFF
--- a/index.html.pre
+++ b/index.html.pre
@@ -147,6 +147,11 @@ a.blocked {
 	background-color: #fef2c0;
 	color: black;
 }
+
+.tag-dnm {
+	background-color: #b60205;
+	color: white;
+}
 </style>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js"></script>

--- a/index.html.pre
+++ b/index.html.pre
@@ -121,6 +121,32 @@ a.blocked {
 	margin-top: 10px;
 	margin-bottom: 10px;
 }
+
+.tag {
+	display: inline-block;
+	padding: 0px 6px;
+	border-radius: 4px;
+	font-family: sans-serif;
+	font-size: 12px;
+	font-weight: bold;
+	text-align: center;
+	white-space: nowrap;
+}
+
+.tag-trivial {
+	background-color: #f9d0b1;
+	color: black;
+}
+
+.tag-hotfix {
+	background-color: #b60205;
+	color: white;
+}
+
+.tag-oldci {
+	background-color: #fef2c0;
+	color: black;
+}
 </style>
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.30.1/moment.min.js"></script>
@@ -200,11 +226,15 @@ a.blocked {
 
 <table class="prs" id="author">
   <tr>
-    <th>#</th><th>Title</th><th>Author</th><th>Assignee</th><th>Approvers</th>
+    <th>#</th>
+    <th>Title</th>
+    <th>Tags</th>
+    <th>Author</th>
+    <th>Assignee</th>
+    <th>Approvers</th>
     <th>Base</th>
     <th>Milestone</th>
     <th title="Mergeable">&#8624;</th>
     <th title="Approved">&check;</th>
     <th title="Review time">&#9202;</th>
-    <th title="Tags">&#127991;</th>
   </tr>

--- a/merge_list.py
+++ b/merge_list.py
@@ -74,10 +74,8 @@ def evaluate_criteria(number, data):
 
     if rebaseable is None:
         print(f"re-fetch: {number}")
-        print(f"{rebaseable}")
         pr = data.issue.as_pull_request()
         rebaseable = pr.rebaseable
-        print(f"{rebaseable}")
 
     approvers = set()
     for review in data.pr.get_reviews():

--- a/merge_list.py
+++ b/merge_list.py
@@ -194,15 +194,18 @@ def table_entry(number, data):
 
     tags = []
     if data.hotfix:
-        tags.append("H")
+        tags.append("<span class='tag tag-hotfix'>hotfix</span>")
     if data.trivial:
-        tags.append("T")
+        tags.append("<span class='tag tag-trivial'>trivial</span>")
+    if not data.ci_run_recent:
+        tags.append(f"<span class='tag tag-oldci'>ci {data.ci_age_days}d</span>")
     tags_text = ' '.join(tags)
 
     return f"""
         <tr class="{tr_class}">
             <td><a href="{url}">{number}</a></td>
             <td><a href="{url}">{title}</a></td>
+            <td>{tags_text}</td>
             <td>{author}</td>
             <td>{assignees}</td>
             <td>{approvers}</td>
@@ -211,7 +214,6 @@ def table_entry(number, data):
             <td>{rebaseable}</td>
             <td>{assignee}</td>
             <td>{time}</td>
-            <td>{tags_text}</td>
         </tr>
         """
 

--- a/merge_list.py
+++ b/merge_list.py
@@ -43,6 +43,7 @@ class PRData:
     rebaseable: bool = field(default=False)
     hotfix: bool = field(default=False)
     trivial: bool = field(default=False)
+    dnm: bool = field(default=False)
     ci_age_days: int = field(default=None)
     ci_run_recent: bool = field(default=False)
     debug: list = field(default=None)
@@ -106,6 +107,11 @@ def evaluate_criteria(repo, number, data):
     rebaseable = pr.rebaseable
     hotfix = "Hotfix" in labels
     trivial = "Trivial" in labels
+
+    for label in labels:
+        if "DNM" in label:
+            data.dnm = True
+            break
 
     if rebaseable is None:
         print(f"re-fetch: {number}")
@@ -199,6 +205,8 @@ def table_entry(number, data):
         tags.append("<span class='tag tag-trivial'>trivial</span>")
     if not data.ci_run_recent:
         tags.append(f"<span class='tag tag-oldci'>ci {data.ci_age_days}d</span>")
+    if data.dnm:
+        tags.append("<span class='tag tag-dnm'>dnm</span>")
     tags_text = ' '.join(tags)
 
     return f"""


### PR DESCRIPTION
Rework the tag visualization, show old CI runs and DNM PRs (which should not be there).

Looks somewhat like this:

![x](https://github.com/user-attachments/assets/973e5fc5-5f18-43d2-8206-4bfdec57f0f3)

![x](https://github.com/user-attachments/assets/4e00e9c8-a8b5-4cb1-ac17-4b3f466f4d60)
