### PR TITLE
Drop the "opened x mergeaable PR(s)" alert.

### DIFF
--- a/index.html.pre
+++ b/index.html.pre
@@ -265,8 +265,6 @@ a.blocked {
 
 		if (openedCount === 0) {
 			alert("No mergeable PRs found (PRs need to target 'main' and have three green checkmarks)");
-		} else {
-			alert(`Opened ${openedCount} mergeable PR(s) in new tabs`);
 		}
 	}
 </script>


### PR DESCRIPTION
Seems redundant, I just pressed the button and it just did something, no need for the browser to tell me about it.