### PR TITLE
github: run (tenateively) every 10 minutes

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -2,7 +2,7 @@ name: Update and publish
 
 on:
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '*/10 * * * *'
   push:
     branches:
       - main


### PR DESCRIPTION
The workflow takes longer than 5 minutes, github is already scheduling us way less often than that, no sense trying to push for 5, let's go down to 10 minutes and see if we can get more consistent runs.