### PR TITLE
github: always upload artifacts

### DIFF
--- a/.github/workflows/update.yaml
+++ b/.github/workflows/update.yaml
@@ -46,7 +46,6 @@ jobs:
           path: public
 
       - name: Upload artifacts
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v4
         with:
           path: public


### PR DESCRIPTION
Seems like page artifacts are only retained for a da, normal ones are held for much longer. Do both on the periodic run, there's some useful debugging information there, it's nice to have it for a longer time.