### PR TITLE
do not trigger feature freeze mode on minor release

### DIFF
--- a/merge_list.py
+++ b/merge_list.py
@@ -278,9 +278,12 @@ def detect_feature_freeze_tag(repo):
         if not match:
             continue
 
+        tag_version = tuple(map(int, match.groups()))
+        if tag_version[2] != 0:
+            continue
+
         tags.append(tag.name)
 
-        tag_version = tuple(map(int, match.groups()))
         if tag_version > latest_version:
             latest_version = tag_version
 


### PR DESCRIPTION
The feature freeze mode works by looking for vx.y.z-rc tags without a matching vx.y.z one, this makes the dashboard go in freeze mode and hiding PRs even for minor releases if rc tags are made for those, such as v4.4.1-rc1.

Feature freeze mode is meant to kick in only for major relases, just filter any tag that is not a vx.y.0.